### PR TITLE
Making lambda-local a requirable node.js module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "1.8"
+  - "2.5"
+  - "3.3"
+  - "4.4"
+sudo: false
+#cache:
+#  directories:
+#    - node_modules
+script: 
+    - "cd test && ../node_modules/mocha/bin/mocha"
+

--- a/bin/lambda-local
+++ b/bin/lambda-local
@@ -4,77 +4,73 @@
  * Local executor for Amazon Lambda function
  */
 (function(){
-	var invoke = function () {
-		var lambdalocal = require('../lib/lambdalocal.js');
+	var lambdalocal = require('../lib/lambdalocal.js');
 
-		// process opts
-		var program = require('commander');
-		program
-			.option('-l, --lambdapath [lambda file name]', 'Specify Lambda function file name.')
-			.option('-e, --eventpath [event data file name]', 'Specify event data file name.')
-			.option('-h, --handler [lambda-function handler name (optional)]', 'Lambda function handler name. Default is "handler".')
-			.option('-t, --timeout [timeout seconds (optional)]', 'Seconds until lambda function timeout. Default is 3 seconds.')
-			.option('-c, --callbackforce (optional)', 'Force the function to stop after having called context.done/succeed/fail.')
-			.option('-p, --profile [aws file path (optional)]', 'Read the AWS profile to get the credidentials')
-			.parse(process.argv);
+	// process opts
+	var program = require('commander');
+	program
+		.option('-l, --lambdapath [lambda file name]', 'Specify Lambda function file name.')
+		.option('-e, --eventpath [event data file name]', 'Specify event data file name.')
+		.option('-h, --handler [lambda-function handler name (optional)]', 'Lambda function handler name. Default is "handler".')
+		.option('-t, --timeout [timeout seconds (optional)]', 'Seconds until lambda function timeout. Default is 3 seconds.')
+		.option('-c, --callbackforce (optional)', 'Force the function to stop after having called context.done/succeed/fail.')
+		.option('-p, --profile [aws file path (optional)]', 'Read the AWS profile to get the credidentials')
+		.parse(process.argv);
 
-		var eventPath = program.eventpath;
-		var lambdaPath = program.lambdapath;
-		var lambdaHandler = program.handler;
-		var profilePath = program.profile;
-		var callbackWaitsForEmptyEventLoop = program.callbackforce;
-		if (!lambdaPath || !eventPath) {
-			program.help();
-		}
+	var eventPath = program.eventpath;
+	var lambdaPath = program.lambdapath;
+	var lambdaHandler = program.handler;
+	var profilePath = program.profile;
+	var callbackWaitsForEmptyEventLoop = program.callbackforce;
+	if (!lambdaPath || !eventPath) {
+		program.help();
+	}
 
-		// default handler name
-		if (!lambdaHandler) {
-			lambdaHandler = "handler";
-		}
-		
-		//default callbackWaitsForEmptyEventLoop
-		if(!callbackWaitsForEmptyEventLoop){
-			callbackWaitsForEmptyEventLoop = true;
-		} else {
-			callbackWaitsForEmptyEventLoop = false;
-		}
+	// default handler name
+	if (!lambdaHandler) {
+		lambdaHandler = "handler";
+	}
+	
+	//default callbackWaitsForEmptyEventLoop
+	if(!callbackWaitsForEmptyEventLoop){
+		callbackWaitsForEmptyEventLoop = true;
+	} else {
+		callbackWaitsForEmptyEventLoop = false;
+	}
 
-		// timeout milliseconds
-		var timeoutMs;
-		if (program.timeout) {
-			timeoutMs = program.timeout * 1000;
-		} else {
-			timeoutMs = 3000;
-		}
+	// timeout milliseconds
+	var timeoutMs;
+	if (program.timeout) {
+		timeoutMs = program.timeout * 1000;
+	} else {
+		timeoutMs = 3000;
+	}
 
-		// execute
-		lambdalocal.execute({
-			eventPath: eventPath,
-			lambdaPath: lambdaPath,
-			lambdaHandler: lambdaHandler,
-			profilePath: profilePath,
-			callbackWaitsForEmptyEventLoop: callbackWaitsForEmptyEventLoop,
-			timeoutMs: timeoutMs,
-			callback: function (result) {
-				console.log("-----");
-				if (result == true) {
-					console.log("lambda-local successfully complete.");
-				} else {
-					console.log("lambda-local failed.");
-				}
-				//Finish the process
-				process.exit();
-			}
-		});
-
-		// handling timeout
-		setTimeout(function(){
+	// execute
+	lambdalocal.execute({
+		eventPath: eventPath,
+		lambdaPath: lambdaPath,
+		lambdaHandler: lambdaHandler,
+		profilePath: profilePath,
+		callbackWaitsForEmptyEventLoop: callbackWaitsForEmptyEventLoop,
+		timeoutMs: timeoutMs,
+		callback: function (result) {
 			console.log("-----");
-			console.log("Task timed out after "+(timeoutMs/1000).toFixed(2)+" seconds");
+			if (result == true) {
+				console.log("lambda-local successfully complete.");
+			} else {
+				console.log("lambda-local failed.");
+			}
+			//Finish the process
 			process.exit();
-		}, timeoutMs);
+		}
+	});
 
-	};
+	// handling timeout
+	setTimeout(function(){
+		console.log("-----");
+		console.log("Task timed out after "+(timeoutMs/1000).toFixed(2)+" seconds");
+		process.exit();
+	}, timeoutMs);
 
-	invoke();
 })();

--- a/bin/lambda-local
+++ b/bin/lambda-local
@@ -4,89 +4,62 @@
  * Local executor for Amazon Lambda function
  */
 (function(){
-	var utils = require('../lib/utils.js');
+	var invoke = function () {
+		var lambdalocal = require('../lib/lambdalocal.js');
 
-	// process opts
-	var program = require('commander');
-	program
-		.option('-l, --lambdapath [lambda file name]', 'Specify Lambda function file name.')
-		.option('-e, --eventpath [event data file name]', 'Specify event data file name.')
-		.option('-h, --handler [lambda-function handler name (optional)]', 'Lambda function handler name. Default is "handler".')
-		.option('-t, --timeout [timeout seconds (optional)]', 'Seconds until lambda function timeout. Default is 3 seconds.')
-		.option('-c, --callbackforce (optional)', 'Force the function to stop after having called context.done/succeed/fail.')
-		.option('-p, --profile [aws file path (optional)]', 'Read the AWS profile to get the credidentials')
-		.parse(process.argv);
+		// process opts
+		var program = require('commander');
+		program
+			.option('-l, --lambdapath [lambda file name]', 'Specify Lambda function file name.')
+			.option('-e, --eventpath [event data file name]', 'Specify event data file name.')
+			.option('-h, --handler [lambda-function handler name (optional)]', 'Lambda function handler name. Default is "handler".')
+			.option('-t, --timeout [timeout seconds (optional)]', 'Seconds until lambda function timeout. Default is 3 seconds.')
+			.option('-c, --callbackforce (optional)', 'Force the function to stop after having called context.done/succeed/fail.')
+			.option('-p, --profile [aws file path (optional)]', 'Read the AWS profile to get the credidentials')
+			.parse(process.argv);
 
-	var eventPath = program.eventpath;
-	var lambdaPath = program.lambdapath;
-	var lambdaHandler = program.handler;
-	var profilePath = program.profile;
-	var callbackWaitsForEmptyEventLoop = program.callbackforce;
-	if (!lambdaPath || !eventPath) {
-		program.help();
-	}
+		var eventPath = program.eventpath;
+		var lambdaPath = program.lambdapath;
+		var lambdaHandler = program.handler;
+		var profilePath = program.profile;
+		var callbackWaitsForEmptyEventLoop = program.callbackforce;
+		if (!lambdaPath || !eventPath) {
+			program.help();
+		}
 
-	// default handler name
-	if (!lambdaHandler) {
-		lambdaHandler = "handler";
-	}
-	
-	//default callbackWaitsForEmptyEventLoop
-	if(!callbackWaitsForEmptyEventLoop){
-		callbackWaitsForEmptyEventLoop = true;
-	} else {
-		callbackWaitsForEmptyEventLoop = false;
-	}
+		// default handler name
+		if (!lambdaHandler) {
+			lambdaHandler = "handler";
+		}
+		
+		//default callbackWaitsForEmptyEventLoop
+		if(!callbackWaitsForEmptyEventLoop){
+			callbackWaitsForEmptyEventLoop = true;
+		} else {
+			callbackWaitsForEmptyEventLoop = false;
+		}
 
-	//load profile
-	if(profilePath){
-		utils.loadAWSFile(utils.getAbsolutePath(profilePath));
-	}
-	
-	// load lambda function
-	var lambdaAbsolutePath = utils.getAbsolutePath(lambdaPath);
-	var lambdaFunc = require(lambdaAbsolutePath);
+		// timeout milliseconds
+		var timeoutMs;
+		if (program.timeout) {
+			timeoutMs = program.timeout * 1000;
+		} else {
+			timeoutMs = 3000;
+		}
 
-	// load event & context
-	var eventAbsolutePath = utils.getAbsolutePath(eventPath);
-	var _event = require(eventAbsolutePath);
-	var _context = require('../lib/context.js');
+		// execute
+		lambdalocal.execute({
+			eventPath: eventPath,
+			lambdaPath: lambdaPath,
+			lambdaHandler: lambdaHandler,
+			profilePath: profilePath,
+			callbackWaitsForEmptyEventLoop: callbackWaitsForEmptyEventLoop,
+			timeoutMs: timeoutMs
+		});
 
-	var timeoutMs;
-	if (program.timeout) {
-		timeoutMs = program.timeout * 1000;
-	} else {
-		timeoutMs = 3000;
-	}
-	setTimeout(function(){
-		console.log("Task timed out after "+(timeoutMs/1000).toFixed(2)+" seconds");
+		// is reached if callbackWaitsForEmptyEventLoop is false
 		process.exit();
-	}, timeoutMs);
+	};
 
-	_context._initialize({
-		functionName: lambdaHandler,
-		awsRequestId: _context.createInvokeId,
-		timeoutMs: timeoutMs,
-		callbackWaitsForEmptyEventLoop: callbackWaitsForEmptyEventLoop
-	});
-	// export the LAMBDA_TASK_ROOT enviroment variable
-	process.env['LAMBDA_TASK_ROOT'] = process.cwd();
-	
-	//setting common other vars environments 
-	process.env['NODE_PATH'] = utils.getAbsolutePath("node_modules");
-	process.env['LAMBDA_CONSOLE_SOCKET'] = 14;
-	process.env['LAMBDA_CONTROL_SOCKET'] = 11;
-	process.env['AWS_SESSION_TOKEN'] = _context.awsRequestId; /*Just a random value...*/
-	
-	// execute lambda function
-	console.log("Logs");
-	console.log("------");
-	console.log("START RequestId: " + _context.awsRequestId);
-
-	lambdaFunc[lambdaHandler](_event, _context, _context.done);
-	
-	if(callbackWaitsForEmptyEventLoop){		
-		//Finish the process
-		process.exit();
-	}
+	invoke();
 })();

--- a/bin/lambda-local
+++ b/bin/lambda-local
@@ -67,6 +67,13 @@
 			}
 		});
 
+		// handling timeout
+		setTimeout(function(){
+			console.log("-----");
+			console.log("Task timed out after "+(timeoutMs/1000).toFixed(2)+" seconds");
+			process.exit();
+		}, timeoutMs);
+
 	};
 
 	invoke();

--- a/bin/lambda-local
+++ b/bin/lambda-local
@@ -73,7 +73,7 @@
 	process.env['LAMBDA_TASK_ROOT'] = process.cwd();
 	
 	//setting common other vars environments 
-	process.env['NODE_PATH'] = Utils.getAbsolutePath("node_modules");
+	process.env['NODE_PATH'] = utils.getAbsolutePath("node_modules");
 	process.env['LAMBDA_CONSOLE_SOCKET'] = 14;
 	process.env['LAMBDA_CONTROL_SOCKET'] = 11;
 	process.env['AWS_SESSION_TOKEN'] = _context.awsRequestId; /*Just a random value...*/

--- a/bin/lambda-local
+++ b/bin/lambda-local
@@ -54,11 +54,19 @@
 			lambdaHandler: lambdaHandler,
 			profilePath: profilePath,
 			callbackWaitsForEmptyEventLoop: callbackWaitsForEmptyEventLoop,
-			timeoutMs: timeoutMs
+			timeoutMs: timeoutMs,
+			callback: function (result) {
+				console.log("-----");
+				if (result == true) {
+					console.log("lambda-local successfully complete.");
+				} else {
+					console.log("lambda-local failed.");
+				}
+				//Finish the process
+				process.exit();
+			}
 		});
 
-		// is reached if callbackWaitsForEmptyEventLoop is false
-		process.exit();
 	};
 
 	invoke();

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+/*
+ * configuration for lambda-local being called from a program.
+ */
+
+var LambdaLocal = require('./lib/lambdalocal.js');
+module.exports = LambdaLocal;
+

--- a/lib/context.js
+++ b/lib/context.js
@@ -40,6 +40,14 @@ Context.identity = null;
 Context.clientContext = null;
 
 /*
+ * callback function called after done
+ */
+Context.callback = function (result) {
+	console.log("default context callback");
+	return result;
+};
+
+/*
  * create random invokeid. 
  * Assuming that invokeid follows the format: 
  * 8hex-4hex-4hex-4hex-12hex
@@ -90,7 +98,7 @@ Context.done = function (err, message) {
 		utils.outputJSON(message);
 	}
 	if(!Context.callbackWaitsForEmptyEventLoop){
-		process.exit();
+		Context.callback(true);
 	}
 };
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -23,7 +23,7 @@ function Context () {};
 /*
  * exports
  */
-module.exports = exports = Context;
+module.exports = Context;
 
 /*
  * Context object properties

--- a/lib/lambdalocal.js
+++ b/lib/lambdalocal.js
@@ -13,58 +13,57 @@ function LambdaLocal () {};
  */
 module.exports = LambdaLocal;
 
-	LambdaLocal.execute = function (opts) {
-		var eventPath = opts.eventPath;
-		var lambdaPath = opts.lambdaPath;
-		var lambdaHandler = opts.lambdaHandler;
-		var profilePath = opts.profilePath;
-		var callbackWaitsForEmptyEventLoop = opts.callbackWaitsForEmptyEventLoop;
-		var timeoutMs = opts.timeoutMs;
+LambdaLocal.context = require('./context.js');
+LambdaLocal.execute = function (opts) {
+	var eventPath = opts.eventPath;
+	var lambdaPath = opts.lambdaPath;
+	var lambdaHandler = opts.lambdaHandler;
+	var profilePath = opts.profilePath;
+	var callbackWaitsForEmptyEventLoop = opts.callbackWaitsForEmptyEventLoop;
+	var timeoutMs = opts.timeoutMs;
+	var callback = opts.callback;
 
-		//load profile
-		if(profilePath){
-			utils.loadAWSFile(utils.getAbsolutePath(profilePath));
-		}
-		
-		// load lambda function
-		var lambdaAbsolutePath = utils.getAbsolutePath(lambdaPath);
-		var lambdaFunc = require(lambdaAbsolutePath);
+	//load profile
+	if(profilePath){
+		utils.loadAWSFile(utils.getAbsolutePath(profilePath));
+	}
+	
+	// load lambda function
+	var lambdaAbsolutePath = utils.getAbsolutePath(lambdaPath);
+	var lambdaFunc = require(lambdaAbsolutePath);
 
-		// load event & context
-		var eventAbsolutePath = utils.getAbsolutePath(eventPath);
-		var _event = require(eventAbsolutePath);
-		var _context = require('./context.js');
+	// load event & context
+	var eventAbsolutePath = utils.getAbsolutePath(eventPath);
+	var _event = require(eventAbsolutePath);
+	var context = this.context;
 
-		setTimeout(function(){
-			console.log("Task timed out after "+(timeoutMs/1000).toFixed(2)+" seconds");
-			process.exit();
-		}, timeoutMs);
+/*	setTimeout(function(){
+		console.log("Task timed out after "+(timeoutMs/1000).toFixed(2)+" seconds");
+		callback(false);
+	}, timeoutMs);*/
 
-		_context._initialize({
-			functionName: lambdaHandler,
-			awsRequestId: _context.createInvokeId,
-			timeoutMs: timeoutMs,
-			callbackWaitsForEmptyEventLoop: callbackWaitsForEmptyEventLoop
-		});
-		// export the LAMBDA_TASK_ROOT enviroment variable
-		process.env['LAMBDA_TASK_ROOT'] = process.cwd();
-		
-		//setting common other vars environments 
-		process.env['NODE_PATH'] = utils.getAbsolutePath("node_modules");
-		process.env['LAMBDA_CONSOLE_SOCKET'] = 14;
-		process.env['LAMBDA_CONTROL_SOCKET'] = 11;
-		process.env['AWS_SESSION_TOKEN'] = _context.awsRequestId; /*Just a random value...*/
-		
-		// execute lambda function
-		console.log("Logs");
-		console.log("------");
-		console.log("START RequestId: " + _context.awsRequestId);
+	context._initialize({
+		functionName: lambdaHandler,
+		awsRequestId: context.createInvokeId,
+		timeoutMs: timeoutMs,
+		callbackWaitsForEmptyEventLoop: callbackWaitsForEmptyEventLoop
+	});
+	// export the LAMBDA_TASK_ROOT enviroment variable
+	process.env['LAMBDA_TASK_ROOT'] = process.cwd();
+	
+	//setting common other vars environments 
+	process.env['NODE_PATH'] = utils.getAbsolutePath("node_modules");
+	process.env['LAMBDA_CONSOLE_SOCKET'] = 14;
+	process.env['LAMBDA_CONTROL_SOCKET'] = 11;
+	process.env['AWS_SESSION_TOKEN'] = context.awsRequestId; /*Just a random value...*/
+	
+	// execute lambda function
+	console.log("Logs");
+	console.log("------");
+	console.log("START RequestId: " + context.awsRequestId);
 
-		lambdaFunc[lambdaHandler](_event, _context, _context.done);
-		
-		if(callbackWaitsForEmptyEventLoop){
-			return true;
-		}
-	};
+	context.callback = callback;
+	lambdaFunc[lambdaHandler](_event, context, context.done);
+};
 
 

--- a/lib/lambdalocal.js
+++ b/lib/lambdalocal.js
@@ -37,11 +37,6 @@ LambdaLocal.execute = function (opts) {
 	var _event = require(eventAbsolutePath);
 	var context = this.context;
 
-/*	setTimeout(function(){
-		console.log("Task timed out after "+(timeoutMs/1000).toFixed(2)+" seconds");
-		callback(false);
-	}, timeoutMs);*/
-
 	context._initialize({
 		functionName: lambdaHandler,
 		awsRequestId: context.createInvokeId,

--- a/lib/lambdalocal.js
+++ b/lib/lambdalocal.js
@@ -1,0 +1,70 @@
+/*
+ * Lambda's Context object.
+ * Refer to this documentation: 
+ * https://docs.aws.amazon.com/en_us/lambda/latest/dg/nodejs-prog-model-context.html
+ */
+
+var utils = require('./utils.js');
+
+function LambdaLocal () {};
+
+/*
+ * exports
+ */
+module.exports = LambdaLocal;
+
+	LambdaLocal.execute = function (opts) {
+		var eventPath = opts.eventPath;
+		var lambdaPath = opts.lambdaPath;
+		var lambdaHandler = opts.lambdaHandler;
+		var profilePath = opts.profilePath;
+		var callbackWaitsForEmptyEventLoop = opts.callbackWaitsForEmptyEventLoop;
+		var timeoutMs = opts.timeoutMs;
+
+		//load profile
+		if(profilePath){
+			utils.loadAWSFile(utils.getAbsolutePath(profilePath));
+		}
+		
+		// load lambda function
+		var lambdaAbsolutePath = utils.getAbsolutePath(lambdaPath);
+		var lambdaFunc = require(lambdaAbsolutePath);
+
+		// load event & context
+		var eventAbsolutePath = utils.getAbsolutePath(eventPath);
+		var _event = require(eventAbsolutePath);
+		var _context = require('./context.js');
+
+		setTimeout(function(){
+			console.log("Task timed out after "+(timeoutMs/1000).toFixed(2)+" seconds");
+			process.exit();
+		}, timeoutMs);
+
+		_context._initialize({
+			functionName: lambdaHandler,
+			awsRequestId: _context.createInvokeId,
+			timeoutMs: timeoutMs,
+			callbackWaitsForEmptyEventLoop: callbackWaitsForEmptyEventLoop
+		});
+		// export the LAMBDA_TASK_ROOT enviroment variable
+		process.env['LAMBDA_TASK_ROOT'] = process.cwd();
+		
+		//setting common other vars environments 
+		process.env['NODE_PATH'] = utils.getAbsolutePath("node_modules");
+		process.env['LAMBDA_CONSOLE_SOCKET'] = 14;
+		process.env['LAMBDA_CONTROL_SOCKET'] = 11;
+		process.env['AWS_SESSION_TOKEN'] = _context.awsRequestId; /*Just a random value...*/
+		
+		// execute lambda function
+		console.log("Logs");
+		console.log("------");
+		console.log("START RequestId: " + _context.awsRequestId);
+
+		lambdaFunc[lambdaHandler](_event, _context, _context.done);
+		
+		if(callbackWaitsForEmptyEventLoop){
+			return true;
+		}
+	};
+
+

--- a/test/test-event.js
+++ b/test/test-event.js
@@ -1,0 +1,6 @@
+module.exports = {
+  "key1": "value1",
+  "key2": "value2",
+  "key3": "value3"
+};
+

--- a/test/test-func.js
+++ b/test/test-func.js
@@ -1,0 +1,11 @@
+/*
+ * Lambda function used for test.
+ */
+exports.handler = function(event, context) {
+    console.log('value1 = ' + event.key1);
+    console.log('value2 = ' + event.key2);
+    console.log('value3 = ' + event.key3);
+    context.done(null, 'function done');  
+};
+
+

--- a/test/test.js
+++ b/test/test.js
@@ -1,28 +1,38 @@
 
 var assert = require('assert');
-var _context = require('../lib/context.js');
 
-var functionName = 'index';
-var awsRequestId = _context.createInvokeId;
+var functionName = 'handler';
 var timeoutMs = 3000;
 
-_context._initialize({
-	functionName: functionName,
-	awsRequestId: awsRequestId,
-	timeoutMs: timeoutMs
-});
-
-describe('Context object', function () {
-	it('should contain initialized functionName', function () {
-		assert.equal(_context.functionName, functionName);
-	});
-	it('should contain initialized awsRequestId', function () {
-		assert.equal(_context.awsRequestId, awsRequestId);
-	});
-	it('should contain initialized ', function () {
-		assert.equal((_context.getRemainingTimeInMillis() <= timeoutMs), true);
+var lambdalocal = require('../lib/lambdalocal.js');
+var callbackFunc = function (result) {
+	describe('LambdaLocal', function () {
+		it('should return true', function () {
+			assert.equal(result, true);
+		});
 	});
 
+	describe('Context object', function () {
+		it('should contain initialized functionName', function () {
+			assert.equal(lambdalocal.context.functionName, functionName);
+		});
+		it('should contain initialized awsRequestId', function () {
+			assert.equal(lambdalocal.context.awsRequestId.length == 36, true);
+		});
+		it('should contain initialized getRemainingTimeInMillis', function () {
+			assert.equal((lambdalocal.context.getRemainingTimeInMillis() <= timeoutMs), true);
+		});
+	});
+};
+
+lambdalocal.execute({
+	eventPath: './test-event.js',
+	lambdaPath: './test-func.js',
+	lambdaHandler: functionName,
+	profilePath: './debug.aws',
+	callbackWaitsForEmptyEventLoop: false,
+	timeoutMs: timeoutMs,
+	callback: callbackFunc
 });
 
 


### PR DESCRIPTION
A PR for https://github.com/ashiina/lambda-local/issues/22 .
Stuff I did:
 * Separating the command-line handling (command options, process exits) and the actual lambda-local executor
 * Removing `process.exit()` from modules under `lib`, and adopting a callback model instead
 * Wrote a test for `lambdalocal.execute`