### PR TITLE
Fixed issue with AWS Credentials and Windows line endings. Fixes #29

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,18 +35,17 @@ Utils.loadAWSFile = function (path){
 	var fs = require('fs');
 	var data_raw = fs.readFileSync(path);
 	var data = data_raw.toString();
-	
-	var regex = /\[default\](.|\n)*?aws_secret_access_key( ?)+=( ?)+(.*)/;
-	var match = regex.exec(data);
-	if(match[4]){
+
+	var regex = /\[default\](.|\n|\r\n)*?aws_secret_access_key( ?)+=( ?)+(.*)/;
+	var match;
+	if((match = regex.exec(data)) !== null) {
 		process.env['AWS_SECRET_ACCESS_KEY'] = match[4];
 	} else {
 		console.log("WARNING: Couldn't find the \"aws_secret_access_key\" field inside the file.");
 	}
-	
-	regex = /\[default\](.|\n)*?aws_access_key_id( ?)+=( ?)+(.*)/;
-	match = regex.exec(data);
-	if(match[4]) {
+
+	regex = /\[default\](.|\n|\r\n)*?aws_access_key_id( ?)+=( ?)+(.*)/;
+	if((match = regex.exec(data)) !== null) {
 		process.env['AWS_ACCESS_KEY_ID'] = match[4];
 	} else {
 		console.log("WARNING: Couldn't find the \"aws_access_key_id\" field inside the file.");


### PR DESCRIPTION
Also, corrected a potential issue where improperly fomatted AWS credential file would error out instead of sending the "Couldn't find" warning.