### PR TITLE
Improve testing situation

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "devDependencies": {
     "mocha": "^2.4.5"
   },
+  "scripts": {
+    "test": "mocha"
+  },
   "preferGlobal": true,
   "bin": {
     "lambda-local": "./bin/lambda-local"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   "dependencies": {
     "aws-sdk": "^2.1.6",
     "commander": "^2.6.0",
-    "fs": "^0.0.2",
+    "fs": "^0.0.2"
+  },
+  "devDependencies": {
     "mocha": "^2.4.5"
   },
   "preferGlobal": true,

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 
 var assert = require('assert');
+var path = require('path');
 
 var functionName = 'handler';
 var timeoutMs = 3000;
@@ -26,10 +27,10 @@ var callbackFunc = function (result) {
 };
 
 lambdalocal.execute({
-	eventPath: './test-event.js',
-	lambdaPath: './test-func.js',
+	eventPath: path.join(__dirname, './test-event.js'),
+	lambdaPath: path.join(__dirname, './test-func.js'),
 	lambdaHandler: functionName,
-	profilePath: './debug.aws',
+	profilePath: path.join(__dirname, './debug.aws'),
 	callbackWaitsForEmptyEventLoop: false,
 	timeoutMs: timeoutMs,
 	callback: callbackFunc


### PR DESCRIPTION
Moving `mocha` into `devDependencies` allows people to install this in their own projects without having to download `mocha`, since `mocha` is only needed to develop and test this module itself.

I also tried to run `npm test` out of habit and noticed the script wasn't defined. It looked like you needed to `cd` into the `test` folder before running mocha, so now, with help from `path`, you can run the tests regardless of your current working directory.

Thanks for this project! It looks great 🌟 