### PR TITLE
update sample code in README to use JS comment syntax, fix #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Lambda-local
 
 [![Build Status](https://travis-ci.org/ashiina/lambda-local.svg?branch=develop)](https://travis-ci.org/ashiina/lambda-local)
 
-Lambda-local lets you test Amazon Lambda functions on your local machine with sample event data.  
-The `context` of the Lambda function is already loaded so you do not have to worry about it.  
-You can pass any `event` JSON object as you please.  
+Lambda-local lets you test Amazon Lambda functions on your local machine with sample event data.
+The `context` of the Lambda function is already loaded so you do not have to worry about it.
+You can pass any `event` JSON object as you please.
 
 
 Install
@@ -20,7 +20,7 @@ Usage
 
 ```bash
 # Usage
-lambda-local -l index.js -h handler -e event-samples/s3-put.js 
+lambda-local -l index.js -h handler -e event-samples/s3-put.js
 ```
 
 About
@@ -34,19 +34,19 @@ About
 *    -p, --profile [aws file path (optional)]                Read the AWS profile to get the credidentials.
 
 ### Event data
-Event sample data are placed in `event-samples` folder - feel free to use the files in here, or create your own event data.  
-Event data are just JSON objects exported:  
+Event sample data are placed in `event-samples` folder - feel free to use the files in here, or create your own event data.
+Event data are just JSON objects exported:
 
 ```js
-# Sample event data 
+// Sample event data
 module.exports = {
 	foo: "bar"
 };
 ```
 
 ### Context
-The `context` object has been directly extracted from the source visible when running an actual Lambda function on AWS. 
-They may change the internals of this object, and Lambda-local does not guarantee that this will always be up-to-date with the actual context object. 
+The `context` object has been directly extracted from the source visible when running an actual Lambda function on AWS.
+They may change the internals of this object, and Lambda-local does not guarantee that this will always be up-to-date with the actual context object.
 
 ### AWS-SDK
 Since the Amazon Lambda can load the AWS-SDK npm without installation, Lambda-local has also packaged AWS-SDK in its dependencies.


### PR DESCRIPTION
Here's an easy one 😄 

My editor stripped trailing whitespace. Hopefully that's not too annoying.