### PR TITLE
fix 'credentials' spelling in help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ About
 *    -h, --handler [lambda-function handler name (optional)] Lambda function handler name. Default is "handler".
 *    -t, --timeout [timeout seconds (optional)]              Seconds until lambda function timeout. Default is 3 seconds.
 *    -c, --callbackforce (optional)                          Force the function to stop after having called context.done/succeed/fail.
-*    -p, --profile [aws file path (optional)]                Read the AWS profile to get the credidentials.
+*    -p, --profile [aws file path (optional)]                Read the AWS profile to get the credentials.
 
 ### Event data
 Event sample data are placed in `event-samples` folder - feel free to use the files in here, or create your own event data.  

--- a/bin/lambda-local
+++ b/bin/lambda-local
@@ -14,7 +14,7 @@
 		.option('-h, --handler [lambda-function handler name (optional)]', 'Lambda function handler name. Default is "handler".')
 		.option('-t, --timeout [timeout seconds (optional)]', 'Seconds until lambda function timeout. Default is 3 seconds.')
 		.option('-c, --callbackforce (optional)', 'Force the function to stop after having called context.done/succeed/fail.')
-		.option('-p, --profile [aws file path (optional)]', 'Read the AWS profile to get the credidentials')
+		.option('-p, --profile [aws file path (optional)]', 'Read the AWS profile to get the credentials')
 		.parse(process.argv);
 
 	var eventPath = program.eventpath;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,7 +29,7 @@ Utils.outputJSON = function (json) {
 		JSON.stringify(json, null, "\t") : json);
 }
 
-//This will load aws creditentials files
+//This will load aws credentials files
 //more infos: http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files
 Utils.loadAWSFile = function (path){
 	var fs = require('fs');


### PR DESCRIPTION
I noticed a spelling error in the help text and made a quick fix. I updated a couple other places as well. 

Thanks for creating this tool, I've found it really helpful so far. 