### PR TITLE
Remove old random parameter

### DIFF
--- a/lib/lambdalocal.js
+++ b/lib/lambdalocal.js
@@ -90,7 +90,6 @@ var _executeSync = function(opts) {
     process.env['NODE_PATH'] = utils.getAbsolutePath('node_modules');
     process.env['LAMBDA_CONSOLE_SOCKET'] = 14;
     process.env['LAMBDA_CONTROL_SOCKET'] = 11;
-    process.env['AWS_SESSION_TOKEN'] = context.awsRequestId; /*Just a random value...*/
 
     // custom environment variables
     if (environment != null) {


### PR DESCRIPTION
Pretty sure that's the way of fixing https://github.com/ashiina/lambda-local/issues/82

As said [here](https://aws.amazon.com/fr/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/),
> (The aws_session_token value is needed only if you’re including temporary security credentials in the file.)

Since we support https://github.com/ashiina/lambda-local/blob/develop/lib/lambdalocal.js#L72 that's not our case anymore.