### PR TITLE
Update README.md to show right way to use Environment Variablee

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can use Lambda-local as a command line tool.
 lambda-local -l index.js -h handler -e event-samples/s3-put.js
 
 # Input environment variables
-lambda-local -l index.js -h handler -e event-samples/s3-put.js -E {\"key\":\"value\"\,\"key2\":\"value2\"}
+lambda-local -l index.js -h handler -e event-samples/s3-put.js -E "{\"key\":\"value\"\,\"key2\":\"value2\"}"
 
 ```
 


### PR DESCRIPTION
Wrapping up Env Vars in double quotes under 'Usage'