### PR TITLE
Create context.js

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -92,8 +92,7 @@ Context._initialize = function(options) {
 /*
  * This `done` method is directly extracted from source.
  */
-Context.done = function(err, message) {
-	if(unmute != null) {unmute(); unmute = null;}
+Context.done = function(err, message) {	
     if (!Context.callbackWaitsForEmptyEventLoop) {
         Context.callback(err, message);
     }
@@ -107,6 +106,7 @@ Context.done = function(err, message) {
         logger.log('info', '------');
         utils.outputJSON(message, logger);
     }
+    if(unmute != null) {unmute(); unmute = null;}
     if (Context.callbackWaitsForEmptyEventLoop) {
         Context.callback(err, message);
     }


### PR DESCRIPTION
Moved unmute so that the internal logging on lambda local is suppressed.

The reason for this change is that I want to suppress all console.logs eliminating from lambdaLocal.execute