### PR TITLE
unmute at the end

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -93,7 +93,6 @@ Context._initialize = function(options) {
  * This `done` method is directly extracted from source.
  */
 Context.done = function(err, message) {
-	if(unmute != null) {unmute(); unmute = null;}
     if (!Context.callbackWaitsForEmptyEventLoop) {
         Context.callback(err, message);
     }
@@ -110,13 +109,13 @@ Context.done = function(err, message) {
     if (Context.callbackWaitsForEmptyEventLoop) {
         Context.callback(err, message);
     }
+    if(unmute != null) {unmute(); unmute = null;}
 };
 
 /*
  * `fail` method calls the `done` method
  */
 Context.fail = function(err) {
-	if(unmute != null) {unmute(); unmute = null;}
     logger.log('error', 'FAILING!!');
     Context.done(err);
 };
@@ -125,7 +124,6 @@ Context.fail = function(err) {
  * `succeed` method calls the `done` method
  */
 Context.succeed = function(message) {
-	if(unmute != null) {unmute(); unmute = null;}
     Context.done(null, message);
 };
 


### PR DESCRIPTION
Even after I passed in mute=true, lambda-local would still print out these lines to the console:
info: END
error: Error
error: ------
info: 
This fix will suppress all of them.