### PR TITLE
simplify the environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can use Lambda-local as a command line tool.
 lambda-local -l index.js -h handler -e examples/s3-put.js
 
 # Input environment variables
-lambda-local -l index.js -h handler -e examples/s3-put.js -E "{\"key\":\"value\"\,\"key2\":\"value2\"}"
+lambda-local -l index.js -h handler -e examples/s3-put.js -E '{"key":"value","key2":"value2"}'
 
 ```
 


### PR DESCRIPTION
There's a bug in the documentation. The comma doesn't need escaping. While troubleshooting that I figured it would be easier to create the JSON inside single quotes.