### PR TITLE
Fix Lambda ending rules

### DIFF
--- a/bin/lambda-local
+++ b/bin/lambda-local
@@ -110,13 +110,13 @@
             envfile: envfile,
             callback: function(err /*, data */) { //data unused
                 var exec_time = new Date().getTime() - init_time;
-                if (err === null) {
-                    logger.log('info', 'Lambda successfully executed in ' + exec_time + 'ms.');
-                    process.exit(0);
-                } else {
+                if (err !== null && typeof err !== 'undefined') {
                     logger.log('error', 'Lambda failed in ' + exec_time + 'ms.');
                     // Finish the process
                     process.exit(1);
+                } else {
+                    logger.log('info', 'Lambda successfully executed in ' + exec_time + 'ms.');
+                    process.exit(0);
                 }
             },
             verboseLevel: verboseLevel

--- a/lib/context.js
+++ b/lib/context.js
@@ -106,11 +106,16 @@ Context._timeout = null;
  */
 Context.done = function(err, message) {
     clearTimeout(Context._timeout);
-	if(unmute != null) {unmute(); unmute = null;}
+    if(unmute != null) {
+      unmute();
+      unmute = null;
+    }
+
     if (!Context.callbackWaitsForEmptyEventLoop) {
         Context.callback(err, message);
     }
-    if (err != null) {
+
+    if (err !== null && typeof err !== 'undefined') {
         logger.log('error', 'End - Error');
         logger.log('error', '------');
         utils.outputJSON(err, verboseLevel == 1 ? console : logger, 'error');

--- a/test/functs/test-func-cb-0.js
+++ b/test/functs/test-func-cb-0.js
@@ -1,0 +1,6 @@
+/*
+ * Lambda function callback equal 0.
+ */
+exports.handler = function(event, context, callback) {
+    callback(0);
+};

--- a/test/functs/test-func-cb-empty.js
+++ b/test/functs/test-func-cb-empty.js
@@ -1,0 +1,6 @@
+/*
+ * Lambda function callback equal empty string.
+ */
+exports.handler = function(event, context, callback) {
+    callback('');
+};

--- a/test/functs/test-func-cb-fail.js
+++ b/test/functs/test-func-cb-fail.js
@@ -1,0 +1,6 @@
+/*
+ * Lambda function callback failed.
+ */
+exports.handler = function(event, context, callback) {
+    callback('Failed !');
+};

--- a/test/functs/test-func-cb-false.js
+++ b/test/functs/test-func-cb-false.js
@@ -1,0 +1,6 @@
+/*
+ * Lambda function callback equal false.
+ */
+exports.handler = function(event, context, callback) {
+    callback(false);
+};

--- a/test/functs/test-func-cb-null.js
+++ b/test/functs/test-func-cb-null.js
@@ -1,0 +1,6 @@
+/*
+ * Lambda function callback null.
+ */
+exports.handler = function(event, context, callback) {
+    callback(null);
+};

--- a/test/functs/test-func-cb-undefined.js
+++ b/test/functs/test-func-cb-undefined.js
@@ -1,0 +1,6 @@
+/*
+ * Lambda function callback undefined.
+ */
+exports.handler = function(event, context, callback) {
+    callback();
+};

--- a/test/test.js
+++ b/test/test.js
@@ -241,15 +241,61 @@ describe("- Testing bin/lambda-local", function () {
             console.log(r.output.toString('utf8'));
             console.log(r.stderr.toString('utf8'));
         });
+
+        it("should end normally: callback null", function () {
+            var command = get_shell("node ../bin/lambda-local -l ./functs/test-func-cb-null.js -e ./events/test-event.js");
+            var r = spawnSync(command[0], command[1]);
+            assert.equal(r.status, 0);
+            console.log(r.output.toString('utf8'));
+            console.log(r.stderr.toString('utf8'));
+        });
+
+        it("should end normally: callback undefined", function () {
+            var command = get_shell("node ../bin/lambda-local -l ./functs/test-func-cb-undefined.js -e ./events/test-event.js");
+            var r = spawnSync(command[0], command[1]);
+            assert.equal(r.status, 0);
+            console.log(r.output.toString('utf8'));
+            console.log(r.stderr.toString('utf8'));
+        });
     });
+
     describe("* Failing Run", function () {
-        it("should fail", function () {
+        it("should fail: context", function () {
             var command = get_shell("node ../bin/lambda-local -l ./functs/test-func-fail.js -e ./events/test-event.js");
             var r = spawnSync(command[0], command[1]);
             assert.equal(r.status, 1);
             console.log(r.output.toString('utf8'));
         });
+
+        it("should fail: callback string", function () {
+            var command = get_shell("node ../bin/lambda-local -l ./functs/test-func-cb-fail.js -e ./events/test-event.js");
+            var r = spawnSync(command[0], command[1]);
+            assert.equal(r.status, 1);
+            console.log(r.output.toString('utf8'));
+        });
+
+        it("should fail: callback empty string", function () {
+            var command = get_shell("node ../bin/lambda-local -l ./functs/test-func-cb-empty.js -e ./events/test-event.js");
+            var r = spawnSync(command[0], command[1]);
+            assert.equal(r.status, 1);
+            console.log(r.output.toString('utf8'));
+        });
+
+        it("should fail: callback false", function () {
+            var command = get_shell("node ../bin/lambda-local -l ./functs/test-func-cb-false.js -e ./events/test-event.js");
+            var r = spawnSync(command[0], command[1]);
+            assert.equal(r.status, 1);
+            console.log(r.output.toString('utf8'));
+        });
+
+        it("should fail: callback 0", function () {
+            var command = get_shell("node ../bin/lambda-local -l ./functs/test-func-cb-0.js -e ./events/test-event.js");
+            var r = spawnSync(command[0], command[1]);
+            assert.equal(r.status, 1);
+            console.log(r.output.toString('utf8'));
+        });
     });
+
     describe("* Crashing run", function () {
         it("should fail", function () {
             var command = get_shell("node ../bin/lambda-local -l ./functs/test-func-error.js -e ./events/test-event.js");


### PR DESCRIPTION
Lambda should success if given `err` in `context.done` or `callback` is `null` or `undefined`.

[Doc AWS:](http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html#nodejs-prog-model-handler-callback)
```
callback();     // Indicates success but no information returned to the caller.
callback(null); // Indicates success but no information returned to the caller.
callback(null, "success");  // Indicates success with information returned to the caller.
callback(error);    //  Indicates error with error information returned to the caller.
```