### PR TITLE
Read default AWS files

### DIFF
--- a/lib/lambdalocal.js
+++ b/lib/lambdalocal.js
@@ -7,8 +7,9 @@
  */
 
 var logger = require('winston');
-var dotenv = require('dotenv');
 
+const dotenv = require('dotenv');
+const fs = require('fs');
 const utils = require('./utils.js');
     
 var _setLogger = function(_logger){
@@ -73,8 +74,6 @@ var _executeSync = function(opts) {
     }
     
     // set environment variables before the require
-    process.env['AWS_REGION'] = region || process.env['AWS_REGION'] || 'us-east-1';
-    process.env['AWS_DEFAULT_REGION'] = region || process.env['AWS_DEFAULT_REGION'] || 'us-east-1';
     process.env['AWS_LAMBDA_FUNCTION_NAME'] = lambdaHandler;
     process.env['AWS_LAMBDA_FUNCTION_MEMORY_SIZE'] = 1024;
     process.env['AWS_LAMBDA_FUNCTION_VERSION'] = "1.0";
@@ -88,24 +87,37 @@ var _executeSync = function(opts) {
 
     // custom environment variables
     if (environment != null) {
-      if (envdestroy == null){
-        envdestroy = false;
-      }
-      Object.keys(environment).forEach(function(key) {
-        process.env[key]=environment[key];
-      });
+        if (envdestroy == null){
+            envdestroy = false;
+        }
+        Object.keys(environment).forEach(function(key) {
+            process.env[key]=environment[key];
+        });
     }
 
     // custom environment variables file
     if (envfile != null) {
-      dotenv.config({ path: envfile });
+        dotenv.config({ path: envfile });
     }
 
-    //load profile
-    if (profilePath) {
+    //load profiles
+    profilePath = profilePath || process.env['AWS_SHARED_CREDENTIALS_FILE'];
+    var default_config_file = utils.getAbsolutePath("~/.aws/config");
+    var default_credentials_file = utils.getAbsolutePath("~/.aws/credentials");
+    if (fs.existsSync(default_config_file)) { //Default config file
+        utils.loadAWSCredentials(default_config_file, profileName);
+    }
+    if (fs.existsSync(default_credentials_file)) { //Default credentials file
+        utils.loadAWSCredentials(default_credentials_file, profileName);
+    }
+    if (profilePath) { //Provided config/credentials file
         utils.loadAWSCredentials(profilePath, profileName);
     }
-    
+
+    //post loading profiles environment variables
+    process.env['AWS_REGION'] = region || process.env['AWS_REGION'] || 'us-east-1';
+    process.env['AWS_DEFAULT_REGION'] = region || process.env['AWS_DEFAULT_REGION'] || 'us-east-1';
+
     //Logs
     if (typeof verboseLevel == 'undefined'){
         verboseLevel = 3

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,9 @@
  * Requires
  */
 
-const join = require('path').join;
+const fs = require("fs");
+const os = require("os");
+const join = require("path").join;
 
 /**
  * utility functions
@@ -21,27 +23,25 @@ var _generateRandomHex = function(length) {
 };
 
 var _getAbsolutePath = function(path) {
-    var res = null,
-        homeDir = process.env.HOME || process.env.USERPROFILE;
+    var homeDir = process.env.HOME || process.env.USERPROFILE;
 		
 	var windowsRegex = /([A-Z|a-z]:\\[^*|"<>?\n]*)|(\\\\.*?\\.*)/;
 		
     if (path.match(/^\//) || path.match(windowsRegex)) {
 		//On Windows and linux
-        res = path;
+        return path;
     } else {
         if (path === '~') {
-			//On linux only
-            res = homeDir;
-        } else if (path.slice(0, 2) !== '~/') {
-			//On Windows and linux
-            res = join(process.cwd(), path);
+            return homeDir;
+        } else if (path.slice(0, 2) === '~/') {
+            return join(homeDir, path.slice(2));
+        } else if (path.slice(0, 2) === './') {
+            return join(process.cwd(), path.slice(2));
         } else {
-			//On linux only
-            res = join(homeDir, path.slice(2));
+            return join(process.cwd(), path);
         }
     }
-    return res;
+    return null;
 };
 
 var _outputJSON = function(json, logger, level) {
@@ -62,6 +62,19 @@ TimeoutError.prototype = Object.create(Error.prototype);
 TimeoutError.prototype.name = "TimeoutError";
 TimeoutError.prototype.constructor = TimeoutError;
 
+var _load_var_from_file = function(varname, envname, data, profileName){
+    if(process.env[envname]){
+        //If already set, it overwrites config files
+        return;
+    }
+    var regex = new RegExp('\\[' + profileName +
+        '\\](.|\\n|\\r\\n)*?' + varname + '( ?)+=( ?)+(.*)'),
+        match;
+    if ((match = regex.exec(data)) !== null) {
+        process.env[envname] = match[4];
+    }
+}
+
 var _loadAWSCredentials = function(path) {
     //default parameter
     var profileName = arguments.length <= 1 ||
@@ -71,36 +84,17 @@ var _loadAWSCredentials = function(path) {
     var fs = require('fs'),
         dataRaw = fs.readFileSync(_getAbsolutePath(path)),
         data = dataRaw.toString();
-
-    var regex = new RegExp('\\[' + profileName +
-        '\\](.|\\n|\\r\\n)*?aws_secret_access_key( ?)+=( ?)+(.*)'),
-        match;
-    if ((match = regex.exec(data)) !== null) {
-        process.env['AWS_SECRET_ACCESS_KEY'] = match[4];
-    } else {
-        console.log('warning', 'Couldn\'t find the \'aws_secret_access_key\' field inside the file.');
-    }
-
-    regex = new RegExp('\\[' + profileName + '\\](.|\\n|\\r\\n)*?aws_access_key_id( ?)+=( ?)+(.*)');
-    if ((match = regex.exec(data)) !== null) {
-        process.env['AWS_ACCESS_KEY_ID'] = match[4];
-    } else {
-        console.log('warning', 'Couldn\'t find the \'aws_access_key_id\' field inside the file.');
-    }
     
-    regex = new RegExp('\\[' + profileName + '\\](.|\\n|\\r\\n)*?aws_session_token( ?)+=( ?)+(.*)');
-    if ((match = regex.exec(data)) !== null) {
-        process.env['AWS_SESSION_TOKEN'] = match[4];
-    }
+    _load_var_from_file("aws_secret_access_key", "AWS_SECRET_ACCESS_KEY", data, profileName);
+    _load_var_from_file("aws_access_key_id", "AWS_ACCESS_KEY_ID", data, profileName);
+    _load_var_from_file("aws_session_token", "AWS_SESSION_TOKEN", data, profileName);
+    _load_var_from_file("metadata_service_timeout", "AWS_METADATA_SERVICE_TIMEOUT", data, profileName);
+    _load_var_from_file("metadata_service_num_attempts", "AWS_METADATA_SERVICE_NUM_ATTEMPTS", data, profileName);
+
+    _load_var_from_file("region", "AWS_REGION", data, profileName);
+
     if (process.env['AWS_SESSION_TOKEN'] && (process.env['AWS_ACCESS_KEY_ID'] || process.env['AWS_SECRET_ACCESS_KEY'])){
         console.log('warning', 'Using both auth systems: aws_access_key/id and secret_access_token !');
-    }
-
-    regex = new RegExp('\\[' + profileName +
-        '\\](.|\\n|\\r\\n)*?region( ?)+=( ?)+(.*)'),
-        match;
-    if ((match = regex.exec(data)) !== null) {
-        process.env['AWS_REGION'] = match[4];
     }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,7 @@ describe("- Testing utils.js", function () {
     var utils = require("../lib/utils.js");
     describe("* getAbsolutePath", function () {
         it("should return existing path file", function () {
-            var f_path = utils.getAbsolutePath("test.js");
+            var f_path = utils.getAbsolutePath("./test.js");
             assert.doesNotThrow(function(){fs.accessSync(f_path, fs.F_OK)});
         });
     });
@@ -83,6 +83,9 @@ describe("- Testing lambdalocal.js", function () {
     describe("* Basic Run", function () {
         var done, err;
         before(function (cb) {
+            //For this test: set an environment var which should not be overwritten by lambda-local
+            process.env["AWS_REGION"] = "unicorn-universe";
+            //
             var lambdalocal = require("../lib/lambdalocal.js");
             lambdalocal.setLogger(winston);
             lambdalocal.execute({
@@ -100,7 +103,7 @@ describe("- Testing lambdalocal.js", function () {
                 environment: {
                     "envkey1": "Environment",
                     "envkey2": {"k":"v"},
-                    "envkey3": 123,
+                    "envkey3": 123
                 },
                 envfile: path.join(__dirname, "./other/env"),
                 verboseLevel: 1
@@ -116,7 +119,15 @@ describe("- Testing lambdalocal.js", function () {
                 assert.equal(process.env.envkey4, 'foo');
                 assert.equal(process.env.envkey5, 'bar');
             });
+            it("should not have overwritten already-existing env vars", function () {
+                assert.equal(process.env.AWS_REGION, "unicorn-universe");
+            });
+            after(function (cb){
+                delete process.env["AWS_REGION"];
+                cb();
+            });
         });
+
         describe("# Environment Variables (destroy)", function () {
             var done, err;
             before(function (cb) {
@@ -146,7 +157,6 @@ describe("- Testing lambdalocal.js", function () {
                 assert.equal(!("isnetestlambda" in process.env), true);
             });
         });
-
 
         describe("# AWS credentials", function () {
             it("should return correct credentials", function () {


### PR DESCRIPTION
Also improves absolute detection.
Now follows correctly environment variables priority, knowingly:

- top priority: args passed to lambda-locals with options (e.g. region)
- high priority: already existing env vars
- medium priority: env vars passed using a profile file, passed to lambda-local
- low priority: default/shared aws config files