### PR TITLE
Lambda-local should fail if a syntax or require error happened

### DIFF
--- a/lib/lambdalocal.js
+++ b/lib/lambdalocal.js
@@ -146,25 +146,26 @@ var _executeSync = function(opts) {
             }
         }
     });
-
-    // load lambda function
-    if (!(lambdaFunc)){
-        lambdaFunc = require(utils.getAbsolutePath(lambdaPath));
-    }
-    if(callback) context.callback = callback;
-
-    //load event
-    if (event instanceof Function){
-        event = event();
-    }
     
-    // Handling timeout
-    context._timeout = setTimeout(function() {
-        throw new utils.TimeoutError('Task timed out after ' + (timeoutMs / 1000).toFixed(2) + ' seconds');
-    }, timeoutMs);
-    
-    // execute lambda function
     try {
+        if(callback) context.callback = callback;
+
+        // load lambda function
+        if (!(lambdaFunc)){
+            lambdaFunc = require(utils.getAbsolutePath(lambdaPath));
+        }
+
+        //load event
+        if (event instanceof Function){
+            event = event();
+        }
+
+        // Handling timeout
+        context._timeout = setTimeout(function() {
+            throw new utils.TimeoutError('Task timed out after ' + (timeoutMs / 1000).toFixed(2) + ' seconds');
+        }, timeoutMs);
+
+        // execute lambda function
         var result = lambdaFunc[lambdaHandler](event, context, context.done);
         if (result) {
             if (result.then) {

--- a/test/functs/test-func-require-error.js
+++ b/test/functs/test-func-require-error.js
@@ -1,0 +1,8 @@
+/*
+ * Lambda function require error.
+ */
+const toto = require('doNotExist');
+
+exports.handler = function(event, context, callback) {
+    callback(0);
+};

--- a/test/functs/test-func-syntax-error.js
+++ b/test/functs/test-func-syntax-error.js
@@ -1,0 +1,8 @@
+/*
+ * Lambda function syntax error.
+ */
+
+exports.handler = function(event, context, callback) {
+    callback();
+  }
+};

--- a/test/test.js
+++ b/test/test.js
@@ -401,6 +401,20 @@ describe("- Testing bin/lambda-local", function () {
             assert.equal(r.status, 1);
             console.log(r.output.toString('utf8'));
         });
+
+        it("should fail: syntax error", function () {
+            var command = get_shell("node ../bin/lambda-local -l ./functs/test-func-syntax-error.js -e ./events/test-event.js");
+            var r = spawnSync(command[0], command[1]);
+            assert.equal(r.status, 1);
+            console.log(r.output.toString('utf8'));
+        });
+
+        it("should fail: require error", function () {
+            var command = get_shell("node ../bin/lambda-local -l ./functs/test-func-require-error.js -e ./events/test-event.js");
+            var r = spawnSync(command[0], command[1]);
+            assert.equal(r.status, 1);
+            console.log(r.output.toString('utf8'));
+        });
     });
 
     describe("* Environment test run", function () {


### PR DESCRIPTION
Lambda-local doesn't handle errors if lambda has a syntax or require error.

Old behaviour:
```sh
$ > lambda-local -l index.js -e event_sample.js
info: START RequestId: a630dd9a-41d0-8f20-3497-425233d6e8a6
error:  Error: Cannot find module 'doNotExist'
    at Function.Module._resolveFilename (module.js:555:15)
    at Function.Module._load (module.js:482:25)
    at Module.require (module.js:604:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/path/index.js:5:24)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
$ > echo $?
0
```

New behaviour:
```sh
$ > lambda-local -l index.js -e event_sample.js
info: START RequestId: 56fd4fea-1d59-626a-905f-50e53e530cf6
error: End - Error
error: ------
error: {
	"errorMessage": "Cannot find module 'doNotExist'",
	"errorType": "Error",
	"stackTrace": [
		"Function.Module._resolveFilename (module.js:555:15)",
		"Function.Module._load (module.js:482:25)",
		"Module.require (module.js:604:17)",
		"require (internal/module.js:11:18)",
		"Object.<anonymous> (/path/index.js:5:24)",
		"Module._compile (module.js:660:30)",
		"Object.Module._extensions..js (module.js:671:10)",
		"Module.load (module.js:573:32)",
		"tryModuleLoad (module.js:513:12)",
		"Function.Module._load (module.js:505:3)"
	]
}
error: ------
error: Lambda failed in 12ms.
$ > echo $?
1
```