### PR TITLE
Change Context to add InvokeFunctionArn in the right ARN format

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -65,6 +65,22 @@ const createInvokeId = function() {
 }
 
 /*
+ * create invoked function in the proper format
+ */
+Context.prototype.createInvokeFunctionArn = function() {
+  return [
+    'arn',
+    'aws',
+    'lambda',
+    'region',
+    'account-id',
+    'function',
+    this.functionName,
+    this.functionVersion
+  ].join(':');
+}
+
+/*
  * Context initialization.
  * Called from lambdalocal.js
  */
@@ -82,6 +98,9 @@ Context.prototype._initialize = function(options) {
 
     /* set requestid */
     this.awsRequestId = createInvokeId();
+
+    /* set invokedFunctionArn */
+    this.invokedFunctionArn = this.createInvokeFunctionArn();
 
     /* Set callbackWaitsForEmptyEventLoop */
     this.callbackWaitsForEmptyEventLoop = options.callbackWaitsForEmptyEventLoop;

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,8 @@ var fs = require("fs");
 
 var functionName = "handler";
 var timeoutMs = 3000;
+var functionVersion = 1;
+var invokedFunctionArn = `arn:aws:lambda:region:account-id:function:${functionName}:${functionVersion}`;
 
 var sinon = require("sinon");
 
@@ -152,6 +154,9 @@ describe("- Testing lambdalocal.js", function () {
             });
             it("should contain initialized getRemainingTimeInMillis", function () {
                 assert.isAtMost(done.context.getRemainingTimeInMillis(), timeoutMs);
+            });
+            it("should contain initialized invokedFunctionArn", function () {
+                assert.equal(done.context.invokedFunctionArn, invokedFunctionArn);
             });
             it("should contain done function", function () {
                 assert.isDefined(done.context.done);


### PR DESCRIPTION
Currently the invoked function arn in the context is 'a'
After this change the arn will be in the following format: `arn:aws:lambda:region:account-id:function:<function-name>:<function-version>`