### PR TITLE
Make the Makefile a bit more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
-install:
-	npm install
+install: node_modules
 
-test:
-	make
+test: node_modules
 	cd test && ../node_modules/mocha/bin/mocha test.js
 
-.PHONY: test
+clean:
+	rm -rf $(deadwood)
+
+node_modules: package.json
+	npm install
+
+.PHONY: test install clean
+deadwood := node_modules package-lock.json

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Then you will be able to use in your test.js mocha file, something like:
 
  * Run `make` to install npm modules. (Required to develop & test lambda-local)
  * Run `make test` to execute the mocha test.
+* Run `make clean` to reset the repository.
 
 ## License
 


### PR DESCRIPTION
Running `make` or `make test` will now only install `node_modules` if necessary. If `node_modules` exists already and `package.json` hasn’t changed, there’s no need to run `npm install`.

Running `make clean` will delete `node_modules` and `package-lock.json`, returning the repo to a pristine state.

## Testing Instructions

1. Run `make` on a clean checkout. It should install node packages.
2. Run `make` again. It shouldn’t re-install node packages.
3. Run `make clean`. It should remove `node_modules` and `package-lock.json`.
4. Run `make` again. It should re-install node packages.
5. Update `package.json` in a trivial way, then run `make` again. It should re-install node packages.