### PR TITLE
delete the import of the func from require.cache

### DIFF
--- a/lib/lambdalocal.js
+++ b/lib/lambdalocal.js
@@ -149,6 +149,8 @@ var _executeSync = function(opts) {
     try {
         // load lambda function
         if (!(lambdaFunc)){
+            // delete this function from the require.cache to ensure every dependency is refreshed
+            delete require.cache[utils.getAbsolutePath(lambdaPath)];
             lambdaFunc = require(utils.getAbsolutePath(lambdaPath));
         }
 


### PR DESCRIPTION
To ensure every dependency is loaded from a fresh state, the lambda function needs to get deleted from the require.cache.