### PR TITLE
prevent mixing profiles

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -105,7 +105,7 @@ var _load_var_from_file = function(varname, envname, data, profileName){
         return;
     }
     var regex = new RegExp('\\[' + profileName +
-        '\\](.|\\n|\\r\\n)*?' + varname + '( ?)+=( ?)+(.*)'),
+        '\\]([^\\[].|\\n|\\r\\n)*?' + varname + '( ?)+=( ?)+(.*)'),
         match;
     if ((match = regex.exec(data)) !== null) {
         process.env[envname] = match[4];


### PR DESCRIPTION
prevent mixing of aws profiles

Without this change, the regexp search for the next available token, but don't take profile boundaries (starting with [ ) into consideration. 
Assuming target profile is [default] but the [default] profile don't have an aws_session_token, the procedure would take aws_access_key_id is taken from profile [default] but the the aws_session_token from any other profile which leads to an authorization error