### PR TITLE
Remove AWS-SDK dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,7 @@ The `context` object has been sampled from what's visible when running an actual
 They may change the internals of this object, and Lambda-local does not guarantee that this will always be up-to-date with the actual context object.
 
 ### AWS-SDK
-Since the Amazon Lambda can load the AWS-SDK npm without installation, Lambda-local has also packaged AWS-SDK in its dependencies.
-If you want to use this, please use the `-p` or `-P` options (or their API counterpart) with the aws credentials file. More infos here:
-http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files
+As of version 2.0.0, lambda-local no longer packages AWS-SDK in its dependencies. To run a function that makes use of this module, make sure to install it as a dependency in your project.
 
 ## Other links
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "node": ">=6"
   },
   "dependencies": {
-    "aws-sdk": "^2.689.0",
     "commander": "^6.1.0",
     "dotenv": "^8.2.0",
     "winston": "^3.2.1"

--- a/test/functs/test-func-aws-sdk.js
+++ b/test/functs/test-func-aws-sdk.js
@@ -1,9 +1,0 @@
-/*
- * Lambda function used to test aws-sdk import.
- */
-exports.handler = function(event, context) {
-    const aws = require('aws-sdk');
-    context.succeed({"version": aws.VERSION}); 
-};
-
-

--- a/test/test.js
+++ b/test/test.js
@@ -268,26 +268,6 @@ describe("- Testing lambdalocal.js", function () {
                 });
             });
         });
-        describe("* Test aws-sdk import", function () {
-            it("should return an aws-sdk version >= 2", function (cb) {
-                this.timeout(4000);
-                var lambdalocal = require(lambdalocal_path);
-                lambdalocal.setLogger(winston);
-                var lambdaFunc = require("./functs/test-func-aws-sdk.js");
-                lambdalocal.execute({
-                    event: require(path.join(__dirname, "./events/test-event.js")),
-                    lambdaFunc: lambdaFunc,
-                    lambdaHandler: functionName,
-                    callbackWaitsForEmptyEventLoop: false,
-                    timeoutMs: 1000,
-                    callback: function (_err, _done) {
-                        assert.ok(parseInt(_done.version) >= 2);
-                        cb();
-                    },
-                    verboseLevel: 1
-                });
-            });
-        });
         describe("* Return Error object", function () {
             it("should convert it to correct JSON format", function (cb) {
                 var lambdalocal = require(lambdalocal_path);


### PR DESCRIPTION
Following up on #209, this PR removes `aws-sdk` as a dependency.

As per AWS best practices:

> AWS will include the AWS SDK for NodeJS and Python functions (and update the SDK periodically). However, you should bundle your own SDK and pin your functions to a version of the SDK you have tested. — https://aws.amazon.com/blogs/architecture/best-practices-for-developing-on-aws-lambda/

By removing this dependency, we significantly reduce the package size.

I bumped the version to 2.0.0 because this is technically a breaking change.

Let me know if you have any thoughts/questions. Thanks in advance!

Closes #209.