### PR TITLE
add clear-cache option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,8 @@ import utils = require('./lib/utils');
             'returning. This is false by default because our implementation isn\'t perfect and only "emulates" it.')
         .option('--envdestroy',
             '(optional) Destroy added environment on closing. Defaults to false')
+        .option('--no-clear-cache',
+            '(optional) do not remove the lambda function from require cache.')
         .option('-v, --verboselevel <3/2/1/0>',
             '(optional) Default 3. Level 2 dismiss handler() text, level 1 dismiss lambda-local text ' +
             'and level 0 dismiss also the result.', 3)
@@ -57,7 +59,8 @@ import utils = require('./lib/utils');
         envdestroy = program.envdestroy,
         envfile = program.envfile,
         callbackWaitsForEmptyEventLoop = program.waitEmptyEventLoop,
-        verboseLevel = program.verboselevel;
+        verboseLevel = program.verboselevel,
+        clearCache = program.clearCache;
 
     var port;
     if (program.watch) {
@@ -153,6 +156,7 @@ import utils = require('./lib/utils');
             envdestroy: envdestroy,
             envfile: envfile,
             verboseLevel: verboseLevel,
+            clearCache: clearCache
         };
 
         if(program.watch) {

--- a/src/lambdalocal.ts
+++ b/src/lambdalocal.ts
@@ -124,6 +124,7 @@ function _executeSync(opts) {
         timeoutMs = opts.timeoutMs || 3000,
         verboseLevel = opts.verboseLevel,
         callback = opts.callback,
+        clearCache = opts.clearCache ?? true,
         clientContext = null;
 
     if (opts.clientContext) {
@@ -234,7 +235,9 @@ function _executeSync(opts) {
         // load lambda function
         if (!(lambdaFunc)){
             // delete this function from the require.cache to ensure every dependency is refreshed
-            delete require.cache[lambdaPath];
+            if (clearCache) {
+                delete require.cache[lambdaPath];
+            }
             lambdaFunc = require(lambdaPath);
         }
 


### PR DESCRIPTION
Hi, 

the strategy of deleting the lambda function from the require cache leads to huge memory leaks in our case, as `delete` seems only to remove the cache key, but not the cached object. I guess you could also use something like [decache](https://github.com/dwyl/decache) to cleanly remove the lambda function from cache, but I didn't want to introduce a new dependency to your project. Instead I've added an option to skip the deletion of the cache key, as our dev-server restarts after every code change anyway.