### PR TITLE
Handle JSON parse errors to prevent watch from crashing if a non-JSON request body is received.

### DIFF
--- a/src/lambdalocal.ts
+++ b/src/lambdalocal.ts
@@ -90,9 +90,16 @@ function _getRequestPayload(req, callback) {
         body += chunk.toString();
     });
     req.on('end', () => {
-        const payload = JSON.parse(body);
+        let payload;
+        try {
+            payload = JSON.parse(body);
+        } catch(err) {
+            callback(err);
+            return;
+        }
         if(!payload.event) {
             callback('Invalid body (Expected "event" property)');
+            return;
         }
         callback(null, payload.event);
     });


### PR DESCRIPTION
# The problem
When using lambda-local in `--watch` mode, if you post and empty body or body containing invalid JSON, the lambda-local process crashes.

**Example output when posting empty body:**
```
info: Lambda handler listening on http://localhost:8008
undefined:1


SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at IncomingMessage.<anonymous> (C:\Users\lc1211766\Projects\eVault\src\api\node_modules\lambda-local\build\lambdalocal.js:159:28)
    at IncomingMessage.emit (events.js:412:35)
    at endReadableNT (internal/streams/readable.js:1317:12)
    at processTicksAndRejections (internal/process/task_queues.js:82:21)
```
*(lambda-local process crashes after this error occurs)*

**Example output when posting body that is not valid JSON:**
```
info: Lambda handler listening on http://localhost:8008
undefined:1
x
^

SyntaxError: Unexpected token x in JSON at position 0
    at JSON.parse (<anonymous>)
    at IncomingMessage.<anonymous> (C:\Users\lc1211766\Projects\eVault\src\api\node_modules\lambda-local\build\lambdalocal.js:159:28)
    at IncomingMessage.emit (events.js:412:35)
    at endReadableNT (internal/streams/readable.js:1317:12)
    at processTicksAndRejections (internal/process/task_queues.js:82:21)
```
*(lambda-local process crashes after this error occurs)*

# How this PR fixes the problem
This PR adds a try/catch around the `JSON.parse(body)` call to handle exceptions that can occur while parsing the body and returning them through the callback.

(It also adds a return after the callback for missing payload.event so that it doesn't trigger multiple callbacks in that case)
