### PR TITLE
fix: correctly mirror lambda's behaviour when synchronously returning

### DIFF
--- a/src/lambdalocal.ts
+++ b/src/lambdalocal.ts
@@ -252,7 +252,7 @@ function _executeSync(opts) {
             if (result.then) {
                 result.then(ctx.succeed, ctx.fail);
             } else {
-                ctx.succeed(result);
+                ctx.succeed(null);
             }
         }
     } catch(err){

--- a/test/functs/test-func-synchronous.js
+++ b/test/functs/test-func-synchronous.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2018. Taimos GmbH http://www.taimos.de
+ */
+
+/*
+ * Lambda function used for basic test.
+ */
+exports.handler = function (event, context) {
+  return {
+    statusCode: 200,
+    body: "this response won't go anywhere!",
+  };
+};

--- a/test/test.js
+++ b/test/test.js
@@ -324,6 +324,22 @@ describe("- Testing lambdalocal.js", function () {
             });
         });
     });
+    describe('* Synchronous return', function () {
+        it('should return null', function () {
+            var lambdalocal = require(lambdalocal_path);
+            lambdalocal.setLogger(winston);
+            return lambdalocal.execute({
+                event: require(path.join(__dirname, "./events/test-event.js")),
+                lambdaPath: path.join(__dirname, "./functs/test-func-synchronous.js"),
+                lambdaHandler: functionName,
+                callbackWaitsForEmptyEventLoop: false,
+                timeoutMs: timeoutMs,
+                verboseLevel: 1
+            }).then(data => {
+                assert.isNull(data)
+            })
+        });
+    });
     if (get_node_major_version() >= 2) {
         describe('* Promised Run', function () {
             var opts = {


### PR DESCRIPTION
When a Lambda returns its result synchronously (as opposed to as a Promise, or via the callback / context.succeed), Lambda will ignore the result. This PR makes a small update, so that behaviour is mirrored.

<img width="1146" alt="Screenshot 2022-02-15 at 10 20 14" src="https://user-images.githubusercontent.com/14912729/154031459-b1a91bde-990d-4667-b79d-967d3dbe3ea6.png">
<img width="1133" alt="Screenshot 2022-02-15 at 10 20 20" src="https://user-images.githubusercontent.com/14912729/154031474-cc0f16de-60a2-4bb6-a469-2c6c08ad8b3d.png">

