### PR TITLE
Support Lambda Streaming

### DIFF
--- a/src/lambdalocal.ts
+++ b/src/lambdalocal.ts
@@ -13,6 +13,7 @@ import os = require('os');
 import { createServer, IncomingMessage, ServerResponse } from 'http';
 import utils = require('./lib/utils.js');
 import Context = require('./lib/context.js');
+require("./lib/streaming.js");
 
 /*
  * Lambda local version

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -1,12 +1,15 @@
 import { PassThrough } from "stream";
 
 function streamifyResponse(handler) {
-  return (event, ...rest) =>
+  return (event, context) =>
     new Promise(async (resolve, reject) => {
       const body = new StreamingBody(resolve);
 
       try {
-        await handler(event, body, ...rest); // result is ignored
+        const metadata = await handler(event, body, context); // cb not supported
+        if (!body.headersSent) {
+          body.sendHeader(metadata)
+        }
       } catch (error) {
         reject(error);
       }
@@ -14,12 +17,26 @@ function streamifyResponse(handler) {
 }
 
 class StreamingBody extends PassThrough {
-  constructor(readonly resolve: (metadata) => void) {
+  constructor(private readonly resolve: (metadata) => void) {
     super();
   }
 
-  contentType: string;
+  public headersSent = false
+  sendHeader(metadata: any = {}) {
+    const headers = { ...metadata.headers }
+    if (this.contentType) {
+      headers["Content-Type"] = this.contentType
+    }
 
+    this.resolve({
+      ...metadata,
+      headers,
+      body: this
+    })
+    this.headersSent = true
+  }
+
+  private contentType: string;
   setContentType(contentType) {
     this.contentType = contentType;
   }
@@ -27,14 +44,7 @@ class StreamingBody extends PassThrough {
 
 class HttpResponseStream {
   static from(responseStream: StreamingBody, metadata) {
-    responseStream.resolve({
-      ...metadata,
-      headers: {
-        "Content-Type": responseStream.contentType,
-        ...metadata.headers,
-      },
-      body: responseStream,
-    });
+    responseStream.sendHeader(metadata);
     return responseStream;
   }
 }

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -49,7 +49,7 @@ class HttpResponseStream {
   }
 }
 
-globalThis.awslambda = {
+globalThis.awslambda = globalThis.awslambda || {
   streamifyResponse,
   HttpResponseStream,
 };

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -1,3 +1,12 @@
+/**
+ * Implements Lambda Response Streaming by polyfilling
+ * `awslambda.streamifyResponse` and `awslambda.HttpResponseStream.from`.
+ * 
+ * If they're used, `execute` will return a `ReadableStream` as `body`.
+ * 
+ * See https://aws.amazon.com/fr/blogs/compute/introducing-aws-lambda-response-streaming/ for reference.
+ */
+
 import { PassThrough } from "stream";
 
 function streamifyResponse(handler) {

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -1,0 +1,45 @@
+import { PassThrough } from "stream";
+
+function streamifyResponse(handler) {
+  return (event, ...rest) =>
+    new Promise(async (resolve, reject) => {
+      const body = new StreamingBody(resolve);
+
+      try {
+        await handler(event, body, ...rest); // result is ignored
+      } catch (error) {
+        reject(error);
+      }
+    });
+}
+
+class StreamingBody extends PassThrough {
+  constructor(readonly resolve: (metadata) => void) {
+    super();
+  }
+
+  contentType: string;
+
+  setContentType(contentType) {
+    this.contentType = contentType;
+  }
+}
+
+class HttpResponseStream {
+  static from(responseStream: StreamingBody, metadata) {
+    responseStream.resolve({
+      ...metadata,
+      headers: {
+        "Content-Type": responseStream.contentType,
+        ...metadata.headers,
+      },
+      body: responseStream,
+    });
+    return responseStream;
+  }
+}
+
+globalThis.awslambda = {
+  streamifyResponse,
+  HttpResponseStream,
+};

--- a/test/functs/test-func-streaming-simple.js
+++ b/test/functs/test-func-streaming-simple.js
@@ -1,0 +1,15 @@
+/*
+ * Lambda function used for streaming test.
+ */
+exports.handler = awslambda.streamifyResponse(
+    async (event, responseStream, context) => {
+        responseStream.setContentType("text/plain");
+        
+        responseStream.write("foo");
+        setTimeout(() => {
+            responseStream.write("bar");
+            responseStream.end();
+        }, 100);
+    }
+);
+

--- a/test/functs/test-func-streaming.js
+++ b/test/functs/test-func-streaming.js
@@ -1,0 +1,23 @@
+/*
+ * Lambda function used for streaming test.
+ */
+exports.handler = awslambda.streamifyResponse(
+    async (event, responseStream, context) => {
+        const metadata = {
+            statusCode: 200,
+            headers: {
+                "X-Foo": "Bar"
+            }
+        };
+
+        responseStream.setContentType("text/plain");
+        responseStream = awslambda.HttpResponseStream.from(responseStream, metadata);
+        
+        responseStream.write("foo");
+        setTimeout(() => {
+            responseStream.write("bar");
+            responseStream.end();
+        }, 100);
+    }
+);
+

--- a/test/test.js
+++ b/test/test.js
@@ -470,7 +470,7 @@ describe("- Testing lambdalocal.js", function () {
                         const times = []
                         data.body.on('data', (chunk) => {
                             chunks.push(chunk.toString())
-                            times.push(performance.now())
+                            times.push(Date.now())
                         });
                         data.body.on("end", () => {
                             assert.deepEqual(chunks, ["foo", "bar"])

--- a/test/test.js
+++ b/test/test.js
@@ -453,6 +453,33 @@ describe("- Testing lambdalocal.js", function () {
                     })
                 })
             });
+
+            it('also works without calling HttpResponseStream.from', function () {
+                var lambdalocal = require(lambdalocal_path);
+                lambdalocal.setLogger(winston);
+                return lambdalocal.execute({
+                    event: require(path.join(__dirname, "./events/test-event.js")),
+                    lambdaPath: path.join(__dirname, "./functs/test-func-streaming-simple.js"),
+                    lambdaHandler: functionName,
+                    callbackWaitsForEmptyEventLoop: false,
+                    timeoutMs: timeoutMs,
+                    verboseLevel: 1
+                }).then(function (data) {
+                    return new Promise((resolve, reject) => {
+                        const chunks = []
+                        const times = []
+                        data.body.on('data', (chunk) => {
+                            chunks.push(chunk.toString())
+                            times.push(performance.now())
+                        });
+                        data.body.on("end", () => {
+                            assert.deepEqual(chunks, ["foo", "bar"])
+                            assert.closeTo(times[1] - times[0], 100, 50)
+                            resolve()
+                        });
+                    })
+                })
+            });
         });
     }
 });

--- a/test/test.js
+++ b/test/test.js
@@ -443,7 +443,7 @@ describe("- Testing lambdalocal.js", function () {
                         const times = []
                         data.body.on('data', (chunk) => {
                             chunks.push(chunk.toString())
-                            times.push(performance.now())
+                            times.push(Date.now())
                         });
                         data.body.on("end", () => {
                             assert.deepEqual(chunks, ["foo", "bar"])

--- a/test/test.js
+++ b/test/test.js
@@ -420,6 +420,40 @@ describe("- Testing lambdalocal.js", function () {
                 });
             });
         });
+
+        describe('* Streaming Response', function () {
+            it('should return a readable stream as `body`', function () {
+                var lambdalocal = require(lambdalocal_path);
+                lambdalocal.setLogger(winston);
+                return lambdalocal.execute({
+                    event: require(path.join(__dirname, "./events/test-event.js")),
+                    lambdaPath: path.join(__dirname, "./functs/test-func-streaming.js"),
+                    lambdaHandler: functionName,
+                    callbackWaitsForEmptyEventLoop: false,
+                    timeoutMs: timeoutMs,
+                    verboseLevel: 1
+                }).then(function (data) {
+                    assert.deepEqual(
+                        data.headers,
+                        { "Content-Type": "text/plain", "X-Foo": "Bar" }
+                    );
+
+                    return new Promise((resolve, reject) => {
+                        const chunks = []
+                        const times = []
+                        data.body.on('data', (chunk) => {
+                            chunks.push(chunk.toString())
+                            times.push(performance.now())
+                        });
+                        data.body.on("end", () => {
+                            assert.deepEqual(chunks, ["foo", "bar"])
+                            assert.closeTo(times[1] - times[0], 100, 50)
+                            resolve()
+                        });
+                    })
+                })
+            });
+        });
     }
 });
 describe("- Testing cli.js", function () {


### PR DESCRIPTION
AWS launched support for HTTP Streaming in Lambda a couple of days ago: https://aws.amazon.com/blogs/compute/introducing-aws-lambda-response-streaming/

This PR adds support for this to `lambda-local`. It polyfills the two globals `awslambda.streamifyResponse` and [`awslambda.HttpResponseStream.from`](https://github.com/aws-samples/serverless-patterns/blob/9658bac20acdfac64fc31e4d51d9530026872972/lambda-streaming-large-sam/src/index.js#L25), and makes it so that `execute` returns a `ReadableStream` as `body`, if streaming is used.

I'll leave support for `watch` to a separate PR, so we can keep this one small.