### PR TITLE
Add support for loading ECMAScript modules (#222)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Executes a lambda given the `options` object, which is a dictionary where the ke
 | `lambdaHandler`|optional handler name, default to `handler`|
 | `region`|optional, AWS region, default to `us-east-1`|| `callbackWaitsForEmptyEventLoop`|optional, default to `false`. Setting it to True will wait for an empty loop before returning.|
 | `timeoutMs`|optional, timeout, default to 3000 ms|
+| `esm`|boolean, marks that the script is an ECMAScript module (use import), default false|
 | `environment`|optional, extra environment variables for the lambda|
 | `envfile`|optional, load an environment file before booting|
 | `envdestroy`|optional, destroy added environment on closing, default to false|
@@ -137,6 +138,7 @@ lambdaLocal.execute({
 *    `-e, --event-path <event path>`                    (required --watch is not in use) Specify event data file name.
 *    `-h, --handler <handler name>`                     (optional) Lambda function handler name. Default is "handler".
 *    `-t, --timeout <timeout>`                          (optional) Seconds until lambda function timeout. Default is 3 seconds.
+*    `--esm`                                            (optional) Load lambda function as ECMAScript module.
 *    `-r, --region <aws region>`                        (optional) Sets the AWS region, defaults to us-east-1.
 *    `-P, --profile-path <aws profile name>`            (optional) Read the specified AWS credentials file.
 *    `-p, --profile <aws profile name>`                 (optional) Use with **-P**: Read the AWS profile of the file.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,8 @@ import utils = require('./lib/utils');
         .option('-e, --event-path <path>', '(required if --watch is not in use) Event data file name.')
         .option('-h, --handler <handler name>',
             '(optional) Lambda function handler name. Default is \'handler\'.')
+        .option('--esm',
+            '(optional) Load lambda function as ECMAScript module.')
         .option('-t, --timeout <timeout seconds>',
             '(optional) Seconds until lambda function timeout. Default is 3 seconds.')
         .option('-r, --region <aws region>',
@@ -50,6 +52,7 @@ import utils = require('./lib/utils');
     var eventPath = program.eventPath,
         lambdaPath = program.lambdaPath,
         lambdaHandler = program.handler,
+        esm = program.esm,
         profilePath = program.profilePath,
         profileName = program.profile,
         region = program.region,
@@ -129,6 +132,17 @@ import utils = require('./lib/utils');
             _close_inspector = function(){inspector.close();}
         }
     }
+
+    if (esm) {
+        if (utils.get_node_major_version() < 12) {
+            console.log("Loading ESCMAScript modules not available on NodeJS < 12.0.0.");
+            process.exit(1);
+        }
+        if (program.watch) {
+            console.log("Watch mode not supported for ECMAScript lambda modules.");
+            process.exit(1);
+        }
+    }
     var event = function(){
         if(program.watch) return null;
         return require(utils.getAbsolutePath(eventPath));
@@ -140,6 +154,7 @@ import utils = require('./lib/utils');
             event: event,
             lambdaPath: lambdaPath,
             lambdaHandler: lambdaHandler,
+            esm: esm,
             profilePath: profilePath,
             profileName: profileName,
             region: region,

--- a/test/functs/test-func-esm.mjs
+++ b/test/functs/test-func-esm.mjs
@@ -1,0 +1,3 @@
+export async function handler(event, context) {
+  return {"result": event.key, "context": context}
+}

--- a/test/test.js
+++ b/test/test.js
@@ -482,6 +482,25 @@ describe("- Testing lambdalocal.js", function () {
             });
         });
     }
+    if (get_node_major_version() >= 12) {
+        describe('* Loading ECMAScript module', function () {
+            it('should load ECMAScript lambda module successfully', function () {
+                var lambdalocal = require(lambdalocal_path);
+                lambdalocal.setLogger(winston);
+                return lambdalocal.execute({
+                    event: require(path.join(__dirname, "./events/test-event.js")),
+                    lambdaPath: path.join(__dirname, "./functs/test-func-esm.mjs"),
+                    lambdaHandler: functionName,
+                    esm: true,
+                    callbackWaitsForEmptyEventLoop: false,
+                    timeoutMs: timeoutMs,
+                    verboseLevel: 1
+                }).then(function (data) {
+                    assert.equal(data.result, "testvar")
+                })
+            })
+        })
+    }
 });
 describe("- Testing cli.js", function () {
     var spawnSync = require('child_process').spawnSync;
@@ -570,6 +589,14 @@ describe("- Testing cli.js", function () {
             assert.equal(r.status, 1);
             console.log(r.output);
         });
+
+        it("should fail: esm with unsupported watch mode", function () {
+            var command = get_shell("node ../build/cli.js -l ./functs/test-func-esm.mjs --esm --watch");
+            var r = spawnSync(command[0], command[1]);
+            process_outputs(r);
+            assert.equal(r.status, 1);
+            console.log(r.output);
+        })
     });
 
     describe("* Environment test run", function () {


### PR DESCRIPTION
As mentioned in https://github.com/ashiina/lambda-local/issues/222#issuecomment-1641838410, there are two caveats:

- watch mode is not be supported for ECMAScript modules as the loader cache can't be invalidated (https://github.com/nodejs/node/issues/49442)
- to keep downward compatibility with NodeJS < 16, the dynamic import for the ECMAScript module has to be wrapped in an eval statement (https://github.com/microsoft/TypeScript/issues/43329#issuecomment-1008361973)