### PR TITLE
handle ESM lambda path on Windows

### DIFF
--- a/src/lambdalocal.ts
+++ b/src/lambdalocal.ts
@@ -206,8 +206,9 @@ function _executeSync(opts) {
 	callbackWaitsForEmptyEventLoop = false;
     }
 
-    if (lambdaPath){
-        lambdaPath = utils.getAbsolutePath(lambdaPath);
+    if (lambdaPath) {
+        var esmWindows = esm && process.platform === 'win32';
+        lambdaPath = (esmWindows ? 'file://' : '') + utils.getAbsolutePath(lambdaPath);
     }
 
     // set environment variables before the require

--- a/src/lambdalocal.ts
+++ b/src/lambdalocal.ts
@@ -207,7 +207,7 @@ function _executeSync(opts) {
     }
 
     if (lambdaPath) {
-        var esmWindows = esm && process.platform === 'win32';
+        const esmWindows = esm && process.platform === 'win32';
         lambdaPath = (esmWindows ? 'file://' : '') + utils.getAbsolutePath(lambdaPath);
     }
 


### PR DESCRIPTION
Discovered that setting the esm option to true on Windows will throw the following error when trying to run execute or the CLI.

`Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:`

This fix shouldn't affect any other platforms and should only take effect when the esm option is true.

fixes https://github.com/ashiina/lambda-local/issues/233