### PR TITLE
add context overwrite option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Executes a lambda given the `options` object, which is a dictionary where the ke
 | `verboseLevel`|optional, default 3. Level 2 dismiss handler() text, level 1 dismiss lambda-local text and level 0 dismiss also the result.|
 | `callback`|optional, lambda third parameter [callback][1]. When left out a Promise is returned|
 | `clientContext`|optional, used to populated clientContext property of lambda second parameter (context)
+| `contextOverwrite`| optional, a function that overwrites the context object. It can get and overwrite the values of the context (such as awsRequestId). |
 
 #### `lambdaLocal.setLogger(logger)`
 #### `lambdaLocal.getLogger()`

--- a/src/lambdalocal.ts
+++ b/src/lambdalocal.ts
@@ -187,6 +187,7 @@ function _executeSync(opts) {
         timeoutMs = opts.timeoutMs || 3000,
         verboseLevel = opts.verboseLevel,
         callback = opts.callback,
+        contextOverwrite = opts.contextOverwrite,
         clientContext = null;
 
     if (opts.clientContext) {
@@ -301,6 +302,8 @@ function _executeSync(opts) {
     if(callback) context.callback = callback;
 
     var ctx = context.generate_context();
+
+    if(contextOverwrite) opts.contextOverwrite(ctx);
 
     const executeLambdaFunc = lambdaFunc => {
         try {

--- a/test/test.js
+++ b/test/test.js
@@ -301,6 +301,26 @@ describe("- Testing lambdalocal.js", function () {
             });
         });
     });
+    describe('* Context overwrite', function () {
+        it("Should overwrite context", function(cb){
+            var lambdalocal = require(lambdalocal_path);
+            lambdalocal.execute({
+                event: require(path.join(__dirname, "./events/test-event.js")),
+                lambdaPath: path.join(__dirname, "./functs/test-func.js"),
+                lambdaHandler: functionName,
+                contextOverwrite: function (ctx){
+                    ctx.awsRequestId = "test id";
+                    ctx.functionName = "test function";
+                },
+                callback: function (err, done) {
+                    assert.equal(done.result, "testvar");
+                    assert.equal(done.context.awsRequestId, "test id");
+                    assert.equal(done.context.functionName, "test function");
+                    cb();
+                }
+            });
+        });
+    });
     describe('* Nested Run', function () {
         it("Should handle nested calls properly (context singleton)", function (cb) {
             var lambdalocal = require(lambdalocal_path);


### PR DESCRIPTION
My use case was that I wanted the "awsRequestId" to be something I specified. 
In this issue #225, the proposer seems to want to change the function name to any name. In either case, you can configure it using this additional option.

The added test case becomes a sample.

```
            lambdalocal.execute({
                event: require(path.join(__dirname, "./events/test-event.js")),
                lambdaPath: path.join(__dirname, "./functs/test-func.js"),
                lambdaHandler: functionName,
                contextOverwrite: function (ctx){
                    ctx.awsRequestId = "test id";
                    ctx.functionName = "test function";
                },
                callback: function (err, done) {
                    assert.equal(done.result, "testvar");
                    assert.equal(done.context.awsRequestId, "test id");
                    assert.equal(done.context.functionName, "test function");
                    cb();
                }
            });
```


Specify a function in the optional `contextOverwrite` passed to the `execute` method. That function receives the created context. You can modify the context inside the function.
If you modify `context.done` etc., it is expected that it will not work as expected, but please forgive this as it is the developer's own responsibility.