### PR TITLE
feat: add callback for invocation end with streaming functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Executes a lambda given the `options` object, which is a dictionary where the ke
 | `envdestroy`|optional, destroy added environment on closing, default to false|
 | `verboseLevel`|optional, default 3. Level 2 dismiss handler() text, level 1 dismiss lambda-local text and level 0 dismiss also the result.|
 | `callback`|optional, lambda third parameter [callback][1]. When left out a Promise is returned|
+| `onInvocationEnd`|optional. called once the invocation ended. useful when awslambda.streamifyResponse is used to distinguish between end of response stream and end of invocation. |
 | `clientContext`|optional, used to populated clientContext property of lambda second parameter (context)
 
 #### `lambdaLocal.setLogger(logger)`

--- a/src/lambdalocal.ts
+++ b/src/lambdalocal.ts
@@ -187,6 +187,7 @@ function _executeSync(opts) {
         timeoutMs = opts.timeoutMs || 3000,
         verboseLevel = opts.verboseLevel,
         callback = opts.callback,
+        onInvocationEnd = opts.onInvocationEnd,
         clientContext = null;
 
     if (opts.clientContext) {
@@ -295,7 +296,8 @@ function _executeSync(opts) {
                 });
             }
         },
-        clientContext: clientContext
+        clientContext: clientContext,
+        onInvocationEnd: onInvocationEnd,
     });
 
     if(callback) context.callback = callback;

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -216,6 +216,7 @@ Context.prototype.done = function(err, message) {
         }
     }
     this.finalCallback(); //Destroy env...
+    this.onInvocationEnd();
     /*
     The finalCallback method will be instantly called if 'this.callbackWaitsForEmptyEventLoop' is False
     Otherwise, lambda-local will wait for an empty loop then call it.

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -216,7 +216,7 @@ Context.prototype.done = function(err, message) {
     }
     this.finalCallback(); //Destroy env...
 
-    const isStream = typeof message === "object" && message.body instanceof StreamingBody
+    const isStream = typeof message === "object" && message?.body instanceof StreamingBody
     if (!isStream) {
         this.onInvocationEnd?.();
     }

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -39,6 +39,7 @@ function Context() {
     this.logStreamName = 'Stream name';
     this.identity = null;
     this.clientContext = null;
+    this.onInvocationEnd = null;
 
     /*
      * callback function called after done
@@ -112,6 +113,7 @@ Context.prototype._initialize = function(options) {
         this.unmute = mute();
     }
     this.clientContext = options.clientContext;
+    this.onInvocationEnd = options.onInvocationEnd;
 
     return;
 };
@@ -126,6 +128,8 @@ Context.prototype._init_timeout = function(){
         this.fail(new utils.TimeoutError('Task timed out after ' + (this.timeout / 1000).toFixed(2) + ' seconds'));
     }).bind(this), this.timeout);
 }
+
+export const onInvocationEnd = Symbol('lambda-local - onInvocationEnd'); 
 
 /*
  * Util function used in lambdalocal.js to get parameters for the handler
@@ -149,7 +153,12 @@ Context.prototype.generate_context = function(){
         logStreamName: this.logStreamName,
         identity: this.identity,
         clientContext: this.clientContext,
-        _stopped: false
+        _stopped: false,
+
+        // INTERNAL
+        __lambdaLocal: {
+            onInvocationEnd: this.onInvocationEnd
+        },
     };
     return ctx;
 }

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -130,8 +130,6 @@ Context.prototype._init_timeout = function(){
     }).bind(this), this.timeout);
 }
 
-export const onInvocationEnd = Symbol('lambda-local - onInvocationEnd'); 
-
 /*
  * Util function used in lambdalocal.js to get parameters for the handler
  */

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -8,6 +8,7 @@
 
 import utils = require('./utils.js');
 import mute = require('./mute.js');
+import { StreamingBody } from './streaming.js';
 
 function Context() {
     this.logger = null;
@@ -216,7 +217,12 @@ Context.prototype.done = function(err, message) {
         }
     }
     this.finalCallback(); //Destroy env...
-    this.onInvocationEnd();
+
+    const isStream = typeof message === "object" && message.body instanceof StreamingBody
+    if (!isStream) {
+        this.onInvocationEnd?.();
+    }
+
     /*
     The finalCallback method will be instantly called if 'this.callbackWaitsForEmptyEventLoop' is False
     Otherwise, lambda-local will wait for an empty loop then call it.

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -27,7 +27,7 @@ function streamifyResponse(handler) {
     });
 }
 
-class StreamingBody extends PassThrough {
+export class StreamingBody extends PassThrough {
   constructor(private readonly resolve: (metadata) => void) {
     super();
   }

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -19,8 +19,10 @@ function streamifyResponse(handler) {
         if (!body.headersSent) {
           body.sendHeader(metadata)
         }
+        context.__lambdaLocal.onInvocationEnd?.();
       } catch (error) {
         reject(error);
+        context.__lambdaLocal.onInvocationEnd?.(error);
       }
     });
 }

--- a/test/functs/test-func-streaming.js
+++ b/test/functs/test-func-streaming.js
@@ -18,6 +18,8 @@ exports.handler = awslambda.streamifyResponse(
             responseStream.write("bar");
             responseStream.end();
         }, 100);
+
+        await new Promise(resolve => setTimeout(resolve, 200));
     }
 );
 

--- a/test/test.js
+++ b/test/test.js
@@ -364,6 +364,16 @@ describe("- Testing lambdalocal.js", function () {
                     assert.equal(data.result, "testvar");
                 });
             });
+            it('should call onInvocationEnd', function () {
+                var lambdalocal = require(lambdalocal_path);
+                lambdalocal.setLogger(winston);
+                let invocationEnded = 0
+                opts.onInvocationEnd = () => invocationEnded++
+                return lambdalocal.execute(opts).then(function (data) {
+                    assert.equal(data.result, "testvar");
+                    assert.equal(invocationEnded, 1)
+                });
+            });
             it('should be stateless', function () {
                 var lambdalocal = require(lambdalocal_path);
                 lambdalocal.setLogger(winston);

--- a/test/test.js
+++ b/test/test.js
@@ -435,7 +435,7 @@ describe("- Testing lambdalocal.js", function () {
             it('should return a readable stream as `body`', function () {
                 var lambdalocal = require(lambdalocal_path);
                 lambdalocal.setLogger(winston);
-                let invocationEnded = false
+                let invocationEnded = 0
                 return lambdalocal.execute({
                     event: require(path.join(__dirname, "./events/test-event.js")),
                     lambdaPath: path.join(__dirname, "./functs/test-func-streaming.js"),
@@ -444,7 +444,7 @@ describe("- Testing lambdalocal.js", function () {
                     timeoutMs: timeoutMs,
                     verboseLevel: 1,
                     onInvocationEnd() {
-                        invocationEnded = true
+                        invocationEnded++
                     }
                 }).then(function (data) {
                     assert.deepEqual(
@@ -463,10 +463,10 @@ describe("- Testing lambdalocal.js", function () {
                             assert.deepEqual(chunks, ["foo", "bar"])
                             assert.closeTo(times[1] - times[0], 100, 50)
 
-                            assert.isFalse(invocationEnded)
+                            assert.equal(invocationEnded, 0)
 
                             setTimeout(() => {
-                                assert.isTrue(invocationEnded)    
+                                assert.equal(invocationEnded, 1)    
                                 resolve()
                             }, 200)
                         });


### PR DESCRIPTION
Streaming functions can end the response stream before they finish their invocation. Here's an example function where this applies:

```ts
export const handler = awslambda.streamifyResponse(async (event, responseStream) => {
  responseStream.write("<html>...")
  const data = await fetchFromDB(...)
  responseStream.write(data.as_html())
  responseStream.write("<footer>...")
  responseStream.end()

  await trackRequestInAnalytics()
});
```

If we want to test that this works as intended, we need to ensure that the Lambda continues running after the response stream ended.

For most Lambdas, that's straightforward because the Lambda is killed immediately after the response is sent. Checking if all required work was completed once `opts.callback` is called is sufficient in that case.

For streaming Lambdas though, `opts.callback` is already called when the response headers are sent (aka when `.write` is first called). This is much earlier, and the Lambda can still perform operations after that.

This PR adds  a `onInvocationEnd` callback that gets notified when the Promise returned by the handler resolves. At this point, all operations should be completed, because AWS might kill the Lambda afterwards. `onInvocationEnd` can be used in testing to ensure that's the case.