### PR TITLE
Don't parse body for gateway event

### DIFF
--- a/src/lambdalocal.ts
+++ b/src/lambdalocal.ts
@@ -133,7 +133,7 @@ function _getRequestPayload(req, callback) {
                     time: new Date().toISOString(),
                     timeEpoch: new Date().getTime(),
                 },
-                body: payload,
+                body,
                 isBase64Encoded: req.headers['content-type'] !== 'application/json',
             };
         }

--- a/test/test.js
+++ b/test/test.js
@@ -708,7 +708,7 @@ describe("- Testing cli.js", function () {
                         "hey": "data",
                     },
                     (result) => {
-                        assert.deepEqual(result["body"], {"hey": "data"});
+                        assert.deepEqual(result["body"], JSON.stringify({"hey": "data"}));
                     },
                     cb
                 );


### PR DESCRIPTION
The `body` in the API Gateway event [should be a string](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7ceee3aff5b3bd1489c9714bef2c5c67d29ec17c/types/aws-lambda/trigger/api-gateway-proxy.d.ts#L228).

It is currently being parsed into an object and this is causing issues for lambdas which do `JSON.parse(event)`.